### PR TITLE
Add a global execution context for `HttpServer` requests.

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -73,7 +73,7 @@ object server extends ScalaModule {
       "http4s-circe",
       "http4s-blaze-server",
       "http4s-blaze-client"
-    ).map { dep => ivy"org.http4s::${dep}::0.21.3" } ++ Agg(
+    ).map { dep => ivy"org.http4s::${dep}::0.21.9" } ++ Agg(
       "tapir-core",
       "tapir-json-circe",
       "tapir-http4s-server",

--- a/server/src/main/scala/lsug/HttpServer.scala
+++ b/server/src/main/scala/lsug/HttpServer.scala
@@ -8,6 +8,7 @@ import java.io.File
 
 object HttpServer extends IOApp {
 
+  import scala.concurrent.ExecutionContext.Implicits.global
   import org.http4s.server.blaze._
   import org.http4s.server.middleware.GZip
   import org.http4s.server.staticcontent._
@@ -45,7 +46,7 @@ object HttpServer extends IOApp {
                   client
                 )
               ).use { server =>
-                val sslStream = BlazeServerBuilder[IO]
+                val sslStream = BlazeServerBuilder[IO](global)
                   .bindHttp(httpsPort, "0.0.0.0")
                   .withSslContext(ssl)
                   .withHttpApp(
@@ -68,7 +69,7 @@ object HttpServer extends IOApp {
                   )
                   .serve
 
-                val redirectStream = BlazeServerBuilder[IO]
+                val redirectStream = BlazeServerBuilder[IO](global)
                   .bindHttp(httpPort, "0.0.0.0")
                   .withHttpApp(SSL.redirectApp[IO](httpsPort))
                   .serve


### PR DESCRIPTION
This fixes some of the deprecation warnings in the build.