### PR TITLE
Remove underscores when not required

### DIFF
--- a/server/src/main/scala/lsug/Server.scala
+++ b/server/src/main/scala/lsug/Server.scala
@@ -151,15 +151,15 @@ final class Server[F[_]: Sync: ContextShift: Logger](
     )
 
   def speaker(id: Speaker.Id): F[Option[Speaker]] =
-    decodeMarkup(id)("people", (Read.speaker _))
+    decodeMarkup(id)("people", (Read.speaker))
 
   def venue(id: Venue.Id): F[Option[Venue.Summary]] =
-    decodeMarkup(id)("venues", (Read.venue _))
+    decodeMarkup(id)("venues", (Read.venue))
 
   def venue1(id: Venue.Id): F[Option[Venue.Summary]] =
-    decodeMarkup(id)("venues", (Read.venue _))
+    decodeMarkup(id)("venues", (Read.venue))
   def meetupDotCom(id: Meetup.Id): F[Option[Meetup.MeetupDotCom.Event]] = {
-    decodeMarkup(id)("meetups", (Read.meetupDotCom _))
+    decodeMarkup(id)("meetups", (Read.meetupDotCom))
       .flatMap(_.flatTraverse(meetup.event))
   }
 }

--- a/server/src/main/scala/lsug/Server.scala
+++ b/server/src/main/scala/lsug/Server.scala
@@ -151,15 +151,15 @@ final class Server[F[_]: Sync: ContextShift: Logger](
     )
 
   def speaker(id: Speaker.Id): F[Option[Speaker]] =
-    decodeMarkup(id)("people", (Read.speaker))
+    decodeMarkup(id)("people", Read.speaker)
 
   def venue(id: Venue.Id): F[Option[Venue.Summary]] =
-    decodeMarkup(id)("venues", (Read.venue))
+    decodeMarkup(id)("venues", Read.venue)
 
   def venue1(id: Venue.Id): F[Option[Venue.Summary]] =
-    decodeMarkup(id)("venues", (Read.venue))
+    decodeMarkup(id)("venues", Read.venue)
   def meetupDotCom(id: Meetup.Id): F[Option[Meetup.MeetupDotCom.Event]] = {
-    decodeMarkup(id)("meetups", (Read.meetupDotCom))
+    decodeMarkup(id)("meetups", Read.meetupDotCom)
       .flatMap(_.flatTraverse(meetup.event))
   }
 }


### PR DESCRIPTION
@zainab-ali As discussed yesterday. Thanks for organising the event.
I've learnt about the compiler's conversions of methods to functions when the type is known.
A counter-example to these is the use of `Read.speaker` in `Server.speakerProfile` where there is no expected function type that the compiler can use (at least, that's what I think - please correct me if I'm misunderstanding).