### PR TITLE
Remove magnolify-cats as a dependency

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -68,8 +68,7 @@ object server extends ScalaModule {
     Agg(
       catsEffectDep,
       ivy"io.chrisdavenport::log4cats-slf4j::1.1.1",
-      ivy"ch.qos.logback:logback-classic:1.2.3",
-      ivy"com.spotify::magnolify-cats::0.4.1"
+      ivy"ch.qos.logback:logback-classic:1.2.3"
     ) ++ Agg(
       "http4s-dsl",
       "http4s-circe",

--- a/server/test/src/scala/lsug/markup/DecoderAssertions.scala
+++ b/server/test/src/scala/lsug/markup/DecoderAssertions.scala
@@ -6,7 +6,9 @@ import cats.implicits._
 
 trait DecoderAssertions { self: LsugSuite =>
 
-  import magnolify.cats.auto._
+  implicit val decoderEq: Eq[DecoderError] =
+    Eq.fromUniversalEquals[DecoderError]
+  implicit val decoderShow: Show[DecoderError] = Show.fromToString[DecoderError]
 
   def assertEither[A: Eq: Show](
       decoder: Decoder[A],

--- a/server/test/src/scala/lsug/markup/DecoderSpec.scala
+++ b/server/test/src/scala/lsug/markup/DecoderSpec.scala
@@ -6,11 +6,12 @@ import cats.implicits._
 
 private class DecoderSpec extends LsugSuite with DecoderAssertions {
 
-  import magnolify.cats.auto._
-
   import Pollen._
   import Decoder._
   import DecoderError._
+
+  implicit val tagEq: Eq[Pollen.Tag] = Eq.fromUniversalEquals[Pollen.Tag]
+  implicit val tagShow: Show[Pollen.Tag] = Show.fromToString[Pollen.Tag]
 
   val line: String = "A truth that's told with bad intent"
   val lineP: Pollen = Contents(line)

--- a/server/test/src/scala/lsug/markup/DecodersSpec.scala
+++ b/server/test/src/scala/lsug/markup/DecodersSpec.scala
@@ -2,10 +2,9 @@ package lsug
 package markup
 
 import lsug.protocol._
-import cats.data._
 import cats._
-
-import magnolify.cats.auto._
+import cats.data._
+import cats.implicits._
 
 private class DecodersSpec extends LsugSuite with DecoderAssertions {
 
@@ -19,6 +18,28 @@ private class DecodersSpec extends LsugSuite with DecoderAssertions {
     Tag(name, List(Contents(contents)))
 
   def emptyTag(name: String): Tag = Tag(name, Nil)
+
+  implicit val linkShow: Show[MText.Link] = Show.fromToString[MText.Link]
+  implicit val paragraphShow: Show[Markup.Paragraph] =
+    Show.fromToString[Markup.Paragraph]
+  implicit val markupShow: Show[Markup] = Show.fromToString[Markup]
+  implicit val socialMediaShow: Show[Speaker.SocialMedia] =
+    Show.fromToString[Speaker.SocialMedia]
+  implicit val mediaShow: Show[PMeetup.Media] = Show.fromToString[PMeetup.Media]
+  implicit val materialShow: Show[PMeetup.Material] =
+    Show.fromToString[PMeetup.Material]
+
+  implicit val linkEq: Eq[MText.Link] = Eq.fromUniversalEquals[MText.Link]
+  implicit val strongEq: Eq[MText.Styled.Strong] = Eq[String].contramap(_.text)
+  implicit val strongShow: Show[MText.Styled.Strong] =
+    Show[String].contramap(_.text)
+  implicit val paragraphEq: Eq[Markup.Paragraph] =
+    Eq.fromUniversalEquals[Markup.Paragraph]
+  implicit val speakerEq: Eq[Speaker] = Eq.fromUniversalEquals[Speaker]
+  implicit val mediaEq: Eq[PMeetup.Media] =
+    Eq.fromUniversalEquals[PMeetup.Media]
+  implicit val materialEq: Eq[PMeetup.Material] =
+    Eq.fromUniversalEquals[PMeetup.Material]
 
   val text = "text"
   val textP = Contents(text)


### PR DESCRIPTION
In support of https://scala-open-letter.github.io/, we should remove magnolify-cats